### PR TITLE
Restore .env.example and enhance guidelines

### DIFF
--- a/contributions/.env.example
+++ b/contributions/.env.example
@@ -1,0 +1,17 @@
+# Please neither delete nor this file. Instead, please create the file called
+# `.env` and adjusts params there (don't use '"' and space chars around `=`).
+
+# AWS credentials for S3 access
+AWS_ACCESS_KEY_ID=your_access_key_here
+AWS_SECRET_ACCESS_KEY=your_secret_key_here
+
+# The AWS default region defines the geo location of your S3 bucket.
+# The AWS endpoint URL specifies the accelerated transfer endpoint.
+# Use the default value unless a specific endpoint is required.
+AWS_DEFAULT_REGION=us-east-2
+AWS_ENDPOINT_URL=https://s3.us-east-2.amazonaws.com
+
+# The S3 bucket path used for storing `.zkey` files, contributions,
+# and other ceremony-related data.
+# Make sure this bucket is pre-configured in your AWS account.
+S3BUCKET=s3://pp-trusted-test


### PR DESCRIPTION
The updated instructions clarify that the `.env.example` file should not be deleted. Users are guided to copy it to `.env` and adjust parameters there.